### PR TITLE
Fix unicode string parsing for `OSBSCStar`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ exclude = ["data/*"]
 chrono = "0.4"
 auto_ops = "0.3"
 assert_float_eq = "1"
+unicode-segmentation = "1.11.0"

--- a/src/catalog/osbsc.rs
+++ b/src/catalog/osbsc.rs
@@ -249,7 +249,44 @@ mod tests {
     #[test]
     fn osbscstar_from() {
         let s = String::from("    88  00_01_04.5982692  -48_48_35.492919  0.0046977187  -0.8518927495    5.50   -18.36    -5.82     8.0   0.26   0.29   0.48   0.46   0.38   0.7  5.71          G8III  0.911              224834 9081   τ Phe                        Phe BHHAAAAACAAAAACB-BB--BEE--H ");
-        OSBSCStar::try_from(s).unwrap();
+        let star = OSBSCStar::try_from(s).unwrap();
+        assert_eq!(star.Hipparcos_id.unwrap(), 88_usize);
+        assert_eq!(
+            star.right_ascension_hms.unwrap(),
+            HourMinSec(Sign::Positive, 00, 01, 04.5982692)
+        );
+        assert_eq!(
+            star.declination_dms.unwrap(),
+            DegMinSec(Sign::Negative, 48, 48, 35.492919)
+        );
+        assert_eq!(star.right_ascension_rad.unwrap(), 0.0046977187);
+        assert_eq!(star.declination_rad.unwrap(), -0.8518927495);
+        assert_eq!(star.parallax.unwrap(), 5.50);
+        assert_eq!(star.proper_motion_ra.unwrap(), -18.36);
+        assert_eq!(star.proper_motion_dec.unwrap(), -5.82);
+        assert_eq!(star.radial_velocity.unwrap(), 8.0);
+        assert_eq!(star.right_ascension_rad_err.unwrap(), 0.26);
+        assert_eq!(star.declination_rad_err.unwrap(), 0.29);
+        assert_eq!(star.parallax_err.unwrap(), 0.48);
+        assert_eq!(star.proper_motion_ra_err.unwrap(), 0.46);
+        assert_eq!(star.proper_motion_dec_err.unwrap(), 0.38);
+        assert_eq!(star.radial_velocity_err.unwrap(), 0.7);
+        assert_eq!(star.V_magnitude.unwrap(), 5.71);
+        assert!(star.variability_flag.is_none());
+        assert_eq!(star.spectral_type.unwrap(), String::from("G8III"));
+        assert_eq!(star.BV_magnitude.unwrap(), 0.911);
+        assert!(star.multiplicity_flag.is_none());
+        assert!(star.CCDM_id.is_none());
+        assert_eq!(star.HD_id.unwrap(), 224834);
+        assert_eq!(star.Yale_id.unwrap(), 9081);
+        assert_eq!(star.Bayer_id.unwrap(), String::from("τ Phe"));
+        assert!(star.Flamsteed_id.is_none());
+        assert!(star.proper_name.is_none());
+        assert_eq!(star.constellation.unwrap(), String::from("Phe"));
+        assert_eq!(
+            star.provenence.unwrap(),
+            String::from("BHHAAAAACAAAAACB-BB--BEE--H")
+        );
     }
 
     #[test]

--- a/src/catalog/osbsc.rs
+++ b/src/catalog/osbsc.rs
@@ -6,6 +6,7 @@
 use super::ValidParse;
 use crate::angle::{DegMinSec, HourMinSec, Sign};
 use crate::parse_trim;
+use unicode_segmentation::UnicodeSegmentation;
 
 /// Parse an arc/minute/second field.
 macro_rules! parse_ams {
@@ -192,6 +193,7 @@ impl TryFrom<String> for OSBSCStar {
     type Error = ();
 
     fn try_from(s: String) -> Result<Self, Self::Error> {
+        let g = UnicodeSegmentation::graphemes(s.as_str(), true).collect::<Vec<&str>>();
         let star = Self {
             Hipparcos_id: parse_trim!(usize, s[0..6]),
 
@@ -217,11 +219,11 @@ impl TryFrom<String> for OSBSCStar {
             CCDM_id: parse_trim!(String, s[177..187]),
             HD_id: parse_trim!(usize, s[188..194]),
             Yale_id: parse_trim!(usize, s[195..199]),
-            Bayer_id: parse_trim!(String, s[200..207]),
-            Flamsteed_id: parse_trim!(String, s[208..215]),
-            proper_name: parse_trim!(String, s[216..230]),
-            constellation: parse_trim!(String, s[231..234]),
-            provenence: parse_trim!(String, s[235..262]),
+            Bayer_id: parse_trim!(String, &g[200..207].join("").to_string()),
+            Flamsteed_id: parse_trim!(String, &g[208..215].join("").to_string()),
+            proper_name: parse_trim!(String, &g[216..230].join("").to_string()),
+            constellation: parse_trim!(String, &g[231..234].join("").to_string()),
+            provenence: parse_trim!(String, &g[235..262].join("").to_string()),
         };
         if star.is_valid_parse() {
             Ok(star)

--- a/src/catalog/util.rs
+++ b/src/catalog/util.rs
@@ -7,7 +7,7 @@ macro_rules! parse_trim {
     (String, $s:expr) => {
         match $s.trim() {
             "" => None,
-            _ => Some($s.to_string()),
+            t => Some(t.to_string()),
         }
     };
     ($T:ty, $s:expr) => {


### PR DESCRIPTION
This PR fixes a bug in parsing `OSBSCStar` records from rows of the star catalog file which contain Greek letters.

## Context

The implementation of `try_from` for `OSBSCStar` relies on slicing into a `String`, where the string is a line from the Unicode-formatted `os-bright-star-catalog-hip.utf8` file. It appears that the *intent* of this indexing is to select particular character (grapheme) ranges from the line. However,  `String` slicing in rust accesses bytes, not characters. This difference is important for strings that contain multi-byte characters like Greek letters, as shown in [this example](
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=df9c059922bb3000663c2582222ff4a4).

Many rows in the `os-bright-star-catalog-hip.utf8` file contain a Greek letter in the Bayer_id field.


## Buggy vs expected behavior

Before this PR, the Bayer_id, and all fields after it in the row, were not parsed properly when the Bayer_id contained a Greek letter. The example below shows the actual vs. expected behavior for parsing the star Betelgeuse:

```rust
use starstuff_types::{catalog::osbsc::OSBSCStar, catalog::ValidParse, parse_catalog};

fn main() {
    let stars = parse_catalog!(
        OSBSCStar,
        Path::new("star_data/os_bright_star_catalog/os-bright-star-catalog-hip.utf8"),
        None
    );

    for s in stars {
        if let Some(name) = s.proper_name {
            if name.contains("Betel") {
                println!("HD_id = \"{}\"", s.HD_id.unwrap()); // Ok -- Should be "39801", was "39801"
                println!("Yale_id = \"{}\"", s.Yale_id.unwrap()); // Ok -- Should be "2061", was "3061"
                println!("Bayer_id = \"{}\"", s.Bayer_id.unwrap()); // Should be "α Ori", was "  α Or"
                println!("Flamsteed_id = \"{}\"", s.Flamsteed_id.unwrap()); // Should be "58 Ori", was "  58 Or"
                println!("name = \"{}\"", name); // Should be "Betelgeuse", was "     Betelgeus"
                println!("constellation = \"{}\"", s.constellation.unwrap()); // Should be "Ori", was " Or"
            }
        }
    }
}
```

## Solution

This PR changes `try_from` for `OSBSCStar` to slice by graphemes, not bytes. To do this, it uses the [unicode-segmentation](https://crates.io/crates/unicode-segmentation) crate.

Also, this PR changes `parse_trim!` to actually return the trimmed string.
